### PR TITLE
New Invitation - add defaultPhone to example embeds

### DIFF
--- a/views/candidate-pipeline.ejs
+++ b/views/candidate-pipeline.ejs
@@ -79,7 +79,7 @@
                     <div class="card">
                       <div class="card-header">Background checks</div>
                       <div class="card-body">
-                        <button type="button" data-checkr-candidate-email="<%= candidate.email %>" data-checkr-embed="new-invitation" class="btn btn-sm">New Background Check</button>
+                        <button type="button" data-checkr-candidate-email="<%= candidate.email %>" data-checkr-candidate-phone="<%= candidate.phone %>" data-checkr-embed="new-invitation" class="btn btn-sm">New Background Check</button>
                         <div class="card-text mt-3">
                           <div data-checkr-candidate-email="<%= candidate.email %>" data-checkr-embed="reports-overview"></div>
                         </div>
@@ -126,14 +126,14 @@
 
     document.querySelectorAll("[data-checkr-embed='new-invitation']").forEach(button => {
       button.addEventListener('click', event => {
-        const newInvitationEmbed = new Checkr.Embeds.NewInvitation({...props, ...{defaultEmail: button.dataset.checkrCandidateEmail}});
+        const newInvitationEmbed = new Checkr.Embeds.NewInvitation({...props, defaultEmail: button.dataset.checkrCandidateEmail, defaultPhone: button.dataset.checkrCandidatePhone});
         newInvitationEmbed.modal();
         embed.modal();
       });
     });
-    
+
     document.querySelectorAll("[data-checkr-embed='reports-overview']").forEach(section => {
-      const reportsOverviewEmbed = new Checkr.Embeds.ReportsOverview({...props, ...{defaultEmail: section.dataset.checkrCandidateEmail}});
+      const reportsOverviewEmbed = new Checkr.Embeds.ReportsOverview({...props, defaultEmail: section.dataset.checkrCandidateEmail});
       reportsOverviewEmbed.render(section);
     });
   </script>

--- a/views/candidate-profile-actions.ejs
+++ b/views/candidate-profile-actions.ejs
@@ -125,6 +125,7 @@
     externalCandidateId: 'WEB-SDK-DEMO-001',
     sessionTokenPath: '/session-token-path',
     defaultEmail: 'charlotte@gmail.com',
+    defaultPhone:'415-193-2000',
     fakeMode: true,
     styles
   }


### PR DESCRIPTION
This is part of the Q1 New Invitation Embed enhancements, where we added the capacity to invite by phone number.  

The task here is to go in and add a `defaultPhone` to show the situation of passing a phone number into the embed, in the same way that we already pass `defaultEmail` in.   

Hardcoded text value properly displaying on the "Candidate Profile" page:  
![Screenshot 2024-05-08 at 9 54 11 AM](https://github.com/checkr/checkr-embed-patterns/assets/4551533/603f743e-fa88-4f30-86dc-1c6356cf94f8)
 

Randomized number value properly displaying in the "Candidate Pipeline" page:  
![Screenshot 2024-05-08 at 9 55 25 AM](https://github.com/checkr/checkr-embed-patterns/assets/4551533/31082f7d-6a9a-4613-8e17-21368a91c7ec)

